### PR TITLE
Add Controller, Request, and Tests for Resume Uploads

### DIFF
--- a/app/Http/Controllers/ResumeController.php
+++ b/app/Http/Controllers/ResumeController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\ResumeUploadRequest;
 use App\Models\Resume;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
 class ResumeController extends Controller
@@ -74,14 +75,22 @@ class ResumeController extends Controller
     }
 
     /**
-     * @param int $resumeId
+     * @param Request $request
+     * @param int     $resumeId
      *
      * @return JsonResponse
      */
-    public function deleteResume(int $resumeId): JsonResponse
+    public function deleteResume(Request $request, int $resumeId): JsonResponse
     {
-        $this->resume->destroy([$resumeId]);
+        $user = $request->user();
 
-        return response()->json(['success'], 204);
+        $resume = $this->resume
+            ->where('user_id', $user->id)
+            ->where('id', $resumeId)
+            ->findOrFail();
+
+        $resume->delete();
+
+        return response()->json([], 204);
     }
 }

--- a/app/Http/Controllers/ResumeController.php
+++ b/app/Http/Controllers/ResumeController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\ResumeUploadRequest;
+use App\Models\Resume;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Http\JsonResponse;
+use Illuminate\View\View;
+
+class ResumeController extends Controller
+{
+    /**
+     * @param int $resumeId
+     *
+     * @return View
+     */
+    public function getResume(int $resumeId): View
+    {
+        $resume = Resume::findOrFail($resumeId);
+
+        return view('resume', ['resume' => $resume]);
+    }
+
+    /**
+     * @param int $resumeId
+     *
+     * @return mixed
+     */
+    public function downloadResume(int $resumeId)
+    {
+        $resume = Resume::findOrFail($resumeId);
+
+        return response()->file($resume->resume);
+    }
+
+    /**
+     * @param ResumeUploadRequest $request
+     *
+     * @return JsonResponse
+     */
+    public function upload(ResumeUploadRequest $request): JsonResponse
+    {
+        $user = $request->user();
+        $file = $request->file('resume');
+
+        $path = $file->storeAs(
+            snake_case($user->name),
+            $this->getNewFilename($file)
+        );
+
+        $resume = Resume::create([
+            'user_id' => $user->id,
+            'resume'  => $path
+        ]);
+
+        return response()->json($resume);
+    }
+
+    /**
+     * @param UploadedFile $file
+     *
+     * @return string
+     */
+    protected function getNewFilename(UploadedFile $file): string
+    {
+        $ext = $file->guessExtension();
+
+        return sprintf(
+            'resume.%s',
+            $ext
+        );
+    }
+}

--- a/app/Http/Requests/ResumeUploadRequest.php
+++ b/app/Http/Requests/ResumeUploadRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ResumeUploadRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return $this->user() ?: false;
+    }
+
+    /**
+     * Must be a valid file with .pdf, .doc, or .docx extension
+     * and can not be bigger than 1.5 mb
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'resume' => 'file|mimes:pdf,doc,docx|max:1500'
+        ];
+    }
+}

--- a/app/Models/Resume.php
+++ b/app/Models/Resume.php
@@ -3,8 +3,15 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Resume extends Model
 {
-    //
+    /**
+     * @return BelongsTo
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/Resume.php
+++ b/app/Models/Resume.php
@@ -2,16 +2,57 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * Class Resume
+ *
+ * @package App\Models
+ *
+ * @property int    $id
+ * @property int    $user_id
+ * @property User   $user
+ * @property string $resume
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
 class Resume extends Model
 {
+    /**
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * @var array
+     */
+    protected $fillable = [
+        'id',
+        'user_id',
+        'resume',
+        'created_at',
+        'updated_at',
+    ];
+
     /**
      * @return BelongsTo
      */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        return [
+            'id'         => $this->getAttribute('id'),
+            'path'       => $this->getAttribute('resume'),
+            'created_at' => $this->created_at->toIso8601String()
+        ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace App;
+namespace App\Models;
 
-use App\Models\Profile;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -33,6 +32,14 @@ class User extends Authenticatable
     public function profile() : HasOne
     {
         return $this->hasOne(Profile::class, 'user_id', 'id');
+    }
+
+    /**
+     * @return HasOne
+     */
+    public function resume(): HasOne
+    {
+        return $this->hasOne(Resume::class, 'user_id', 'id');
     }
 
     public function userId() : int

--- a/database/factories/ResumeFactory.php
+++ b/database/factories/ResumeFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+use App\Models\Resume;
+use Faker\Generator as Faker;
+
+$factory->define(Resume::class, function (Faker $faker) {
+    return [
+        'user_id'    => $faker->numberBetween(1, 100),
+        'resume'     => 'fake/file/path.doc',
+        'created_at' => $faker->date('Y-m-d H:i:s'),
+        'updated_at' => $faker->date('Y-m-d H:i:s'),
+    ];
+});

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\User;
 use Faker\Generator as Faker;
 
 /*
@@ -13,7 +14,7 @@ use Faker\Generator as Faker;
 |
 */
 
-$factory->define(App\User::class, function (Faker $faker) {
+$factory->define(User::class, function (Faker $faker) {
     return [
         'name' => $faker->name,
         'email' => $faker->unique()->safeEmail,

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ Auth::routes();
 
 Route::get('/home', 'HomeController@index')->name('home');
 
-Route::get('/resume/{id}/download', 'ResumeController@downloadResume')->name('downloadResume');
-Route::get('/resume/{id}', 'ResumeController@getResume')->name('viewResume');
-Route::post('/resume', 'ResumeController@upload')->name('uploadResume');
+Route::get('/resumes/{id}/download', 'ResumeController@downloadResume')->name('downloadResume');
+Route::get('/resumes/{id}', 'ResumeController@getResume')->name('viewResume');
+Route::post('/resumes', 'ResumeController@upload')->name('uploadResume');
+Route::delete('/resumes/{id}', 'ResumeController@delete')->name('deleteResume');

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,3 +19,7 @@ Route::get('/{vue_capture?}', function () {
 Auth::routes();
 
 Route::get('/home', 'HomeController@index')->name('home');
+
+Route::get('/resume/{id}/download', 'ResumeController@downloadResume')->name('downloadResume');
+Route::get('/resume/{id}', 'ResumeController@getResume')->name('viewResume');
+Route::post('/resume', 'ResumeController@upload')->name('uploadResume');

--- a/tests/Unit/ResumeControllerTest.php
+++ b/tests/Unit/ResumeControllerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Controllers\ResumeController;
+use App\Http\Requests\ResumeUploadRequest;
+use App\Models\Resume;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ResumeControllerTest extends TestCase
+{
+    public function testGetResume()
+    {
+        $resumeId = 123;
+        $resume = factory(Resume::class)
+            ->make(['id' => $resumeId]);
+
+        $mock = \Mockery::mock(Resume::class);
+        $mock->shouldReceive('findOrFail')
+            ->with($resumeId)
+            ->andReturn($resume);
+
+        $controller = new ResumeController($mock);
+
+        $response = $controller->getResume($resumeId);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+
+        $content = json_decode($response->getContent(), true);
+        $this->assertSame($resumeId, $content['id']);
+    }
+
+    public function testDownloadResume()
+    {
+        $resumeId = 123;
+        $resume = factory(Resume::class)->make(['id' => $resumeId]);
+
+        $mock = \Mockery::mock(Resume::class);
+        $mock->shouldReceive('findOrFail')
+            ->with($resumeId)
+            ->andReturn($resume);
+
+        $controller = new ResumeController($mock);
+        $response = $controller->getResume($resumeId);
+        $this->assertInstanceOf(JsonResponse::class, $response);
+    }
+
+    public function testUpload()
+    {
+        $file = UploadedFile::fake()->create('resume.pdf', 500);
+        $user = factory(User::class)->make(['user_id' => 123]);
+
+        $request = \Mockery::mock(ResumeUploadRequest::class);
+        $request->shouldReceive('user')->andReturn($user);
+        $request->shouldReceive('file')->with('resume')->andReturn($file);
+
+        Storage::fake('resumes');
+
+        $mock = \Mockery::mock(Resume::class);
+        $mock->shouldReceive('fill')
+            ->andReturnSelf();
+        $mock->shouldReceive('save')->andReturn(true);
+
+        $controller = new ResumeController($mock);
+
+        $response = $controller->upload($request);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $data = json_decode($response->getContent(), true);
+
+        $this->assertSame($user->id, $data['user_id']);
+
+        $uploadedFile = 'resumes/'. snake_case($user->name). '/resume.pdf';
+        Storage::disk()->assertExists($uploadedFile);
+    }
+}


### PR DESCRIPTION
This PR adds support for 3 routes:

* `GET /resumes/{id}` - Get a resume by Id
* `GET /resumes/{id}/download` - Download a resume
* `POST /resumes` - Upload a new resume
* `DELETE /resumes/{id}` - Delete a resume by ID